### PR TITLE
Adiciona primeira ata de reunião

### DIFF
--- a/docs/atas/ata1.md
+++ b/docs/atas/ata1.md
@@ -1,0 +1,41 @@
+# Ata de Reunião - Requisitos de Software - Grupo 06
+
+**Data:** 11/04/2025  
+**Horário:** 19:30 às 20:30  
+**Local:** Online via Microsoft Teams
+
+---
+
+## Participantes presentes:
+
+- ✅ Andre Lopes
+- ✅ Diassis
+- ✅ João Pedro
+- ✅ José Eduardo
+- ✅ Julia Massuda
+- ✅ Marco Marques
+- ✅ Thales Germano
+
+---
+
+## Discussão:
+
+- Divisão de tarefas para elaboração do cronograma.
+- Visualização do conteúdo dos grupos anteriores.
+
+---
+
+## Decisões:
+
+- Andre Lopes e Julia Massuda serão responsáveis pela produção do richmap
+- Thales Germano responsável pelo cronograma 
+- José Eduardo responsável pelo gitpage e lista de ferramentas usadas 
+- João Pedro será responsável pelo HeatMap
+- Diassis responsável pelas atas e slides da apresentação 
+
+---
+
+## Link da gravação
+
+> [Acesse a gravação da reunião aqui](https://unbbr-my.sharepoint.com/personal/211031593_aluno_unb_br/_layouts/15/stream.aspx?id=%2Fpersonal%2F211031593%5Faluno%5Funb%5Fbr%2FDocuments%2FGrava%C3%A7%C3%B5es%2FREUNI%C3%83O%2001%20%2D%20RS%20%2D%20GRUPO%206%2011%2D04%2019H%2D20250411%5F193110%2DGrava%C3%A7%C3%A3o%20de%20Reuni%C3%A3o%2Emp4&referrer=StreamWebApp%2EWeb&referrerScenario=AddressBarCopied%2Eview%2E2d20a96d%2Dcc45%2D4060%2Db11c%2D62ca032be085)
+


### PR DESCRIPTION
Este Pull Request adiciona a ata da primeira reunião do grupo 06 da disciplina de Requisitos de Software, realizada no dia 11/04/2025.
O documento inclui:

Lista de participantes presentes;

Tópicos discutidos;

Decisões tomadas pelo grupo;

Informações sobre a gravação da reunião.

A ata foi adicionada na branch atas-reuniao como parte da documentação colaborativa do projeto, com o objetivo de manter o registro das decisões e atividades definidas ao longo do semestre.